### PR TITLE
JSLint and JSHint directives should not be flagged as commented out code

### DIFF
--- a/javascript-checks/src/main/java/org/sonar/javascript/checks/CommentedCodeCheck.java
+++ b/javascript-checks/src/main/java/org/sonar/javascript/checks/CommentedCodeCheck.java
@@ -65,7 +65,7 @@ public class CommentedCodeCheck extends SquidCheck<LexerlessGrammar> implements 
 
   public void visitToken(Token token) {
     for (Trivia trivia : token.getTrivia()) {
-      if (trivia.isComment() && !isJsDoc(trivia)) {
+      if (trivia.isComment() && !isJsDoc(trivia) && !isJsLint(trivia)  && !isJsHint(trivia) && !isGlobals(trivia)) {
         String lines[] = regexpToDivideStringByLine.split(getContext().getCommentAnalyser().getContents(trivia.getToken().getOriginalValue()));
         for (int lineOffset = 0; lineOffset < lines.length; lineOffset++) {
           if (codeRecognizer.isLineOfCode(lines[lineOffset])) {
@@ -79,6 +79,18 @@ public class CommentedCodeCheck extends SquidCheck<LexerlessGrammar> implements 
 
   private boolean isJsDoc(Trivia trivia) {
     return trivia.getToken().getValue().startsWith("/**");
+  }
+
+  private boolean isJsLint(Trivia trivia) {
+    return trivia.getToken().getValue().startsWith("/*jslint");
+  }
+
+  private boolean isJsHint(Trivia trivia) {
+    return trivia.getToken().getValue().startsWith("/*jshint");
+  }
+
+  private boolean isGlobals(Trivia trivia) {
+    return trivia.getToken().getValue().startsWith("/*global");
   }
 
 }

--- a/javascript-checks/src/test/java/org/sonar/javascript/checks/CommentedCodeCheckTest.java
+++ b/javascript-checks/src/test/java/org/sonar/javascript/checks/CommentedCodeCheckTest.java
@@ -32,8 +32,8 @@ public class CommentedCodeCheckTest {
   public void test() {
     SourceFile file = JavaScriptAstScanner.scanSingleFile(new File("src/test/resources/checks/commentedCode.js"), new CommentedCodeCheck());
     CheckMessagesVerifier.verify(file.getCheckMessages())
-        .next().atLine(7).withMessage("Sections of code should not be \"commented out\".")
-        .next().atLine(14)
+        .next().atLine(10).withMessage("Sections of code should not be \"commented out\".")
+        .next().atLine(17)
         .noMore();
   }
 

--- a/javascript-checks/src/test/resources/checks/commentedCode.js
+++ b/javascript-checks/src/test/resources/checks/commentedCode.js
@@ -1,3 +1,6 @@
+/*jslint bitwise: false, browser: true, continue: false, devel: true, eqeq: false, evil: false, forin: false, newcap: false, nomen: false, plusplus: true, regexp: true, stupid: false, sub: false, undef: false, vars: false */
+/*jshint bitwise: false, curly: true, eqeqeq: true, forin: true, immed: true, latedef: true, newcap: true, noarg: true, noempty: false, nonew: true, plusplus: false, regexp: false, undef: true, strict: true, trailing: true, expr: true, regexdash: true, browser: true, jquery: true, onevar: true, nomen: true */
+/*global myGlobal: true */
 /**
  * @return {String}
  */


### PR DESCRIPTION
The current version of the sonar-javascript plugin flags JSLint and JSHint directives as commented out code in some instances.

This pull request addresses these false positive in the same way that JSDoc comment blocks are currently handled.

I have updated the unit tests to cover these new checks. The directives I have included in the test are taken from our developer guidelines and match the base ruleset that we use in production.

Background

It may be desirable to include a JSLint or JSHint directive at the top of a JavaScript file.

http://www.jslint.com/lint.html#options
http://www.jshint.com/docs/config/

These allow an IDE to provide feedback during development and increase code portability.

The directives look like JavaScript code, especially when they contain keywords, and trigger the "Sections of code should not be "commented out" rule.