### PR TITLE
SONARJS-451: Update filename building to work on Windows

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/unittest/jstestdriver/JsTestDriverSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/unittest/jstestdriver/JsTestDriverSensor.java
@@ -93,7 +93,7 @@ public class JsTestDriverSensor implements Sensor {
   protected String getUnitTestFileName(String className) {
     // For JsTestDriver assume notation com.company.MyJsTest that maps to com/company/MyJsTest.js
     String fileName = getUnitTestClassName(className);
-    fileName = fileName.replace('.', File.separator.charAt(0));
+    fileName = fileName.replace('.', File.separatorChar);
     fileName = fileName + ".js";
     return fileName;
   }

--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/unittest/jstestdriver/JsTestDriverSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/unittest/jstestdriver/JsTestDriverSensor.java
@@ -93,7 +93,7 @@ public class JsTestDriverSensor implements Sensor {
   protected String getUnitTestFileName(String className) {
     // For JsTestDriver assume notation com.company.MyJsTest that maps to com/company/MyJsTest.js
     String fileName = getUnitTestClassName(className);
-    fileName = fileName.replace('.', '/');
+    fileName = fileName.replace('.', File.separator.charAt(0));
     fileName = fileName + ".js";
     return fileName;
   }


### PR DESCRIPTION
The building of the fileName variable was assuming a forward slash character which fails to match the actual path of the file on Windows platforms causing test results to not be imported.  Use native os file separator instead.