### PR TITLE
SONARJS-463 fix searching for test file corresponding to filename when filename c…

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/unittest/jstestdriver/JsTestDriverSensor.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/unittest/jstestdriver/JsTestDriverSensor.java
@@ -20,6 +20,7 @@
 package org.sonar.plugins.javascript.unittest.jstestdriver;
 
 import java.io.File;
+import java.util.Iterator;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -103,13 +104,17 @@ public class JsTestDriverSensor implements Sensor {
   }
 
   protected InputFile getTestFileRelativePathToBaseDir(String fileName) {
-    for (InputFile inputFile : fileSystem.inputFiles(testFilePredicate)) {
+    FilePredicate predicate = fileSystem.predicates().and(
+            testFilePredicate,
+            fileSystem.predicates().matchesPathPattern("**" + File.separatorChar + fileName)
+    );
 
-      if (inputFile.file().getAbsolutePath().endsWith(fileName)) {
-        LOG.debug("Found potential test file corresponding to file name: {}", fileName);
-        LOG.debug("Will fetch SonarQube associated resource with (logical) relative path to project base directory: {}", inputFile.relativePath());
-        return inputFile;
-      }
+    Iterator<InputFile> fileIterator = fileSystem.inputFiles(predicate).iterator();
+    if (fileIterator.hasNext()) {
+      InputFile inputFile = fileIterator.next();
+      LOG.debug("Found potential test file corresponding to file name: {}", fileName);
+      LOG.debug("Will fetch SonarQube associated resource with (logical) relative path to project base directory: {}", inputFile.relativePath());
+      return inputFile;
     }
     return null;
   }

--- a/sonar-javascript-plugin/src/test/resources/org/sonar/plugins/javascript/unittest/jstestdriver/sensortests/test/AnotherPersonTest.js
+++ b/sonar-javascript-plugin/src/test/resources/org/sonar/plugins/javascript/unittest/jstestdriver/sensortests/test/AnotherPersonTest.js
@@ -1,0 +1,1 @@
+This is content for AnotherPersonTest.js JavaScript file used in unit tests.

--- a/sonar-javascript-plugin/src/test/resources/org/sonar/plugins/javascript/unittest/jstestdriver/sensortests/test/awesome/AnotherPersonTest.js
+++ b/sonar-javascript-plugin/src/test/resources/org/sonar/plugins/javascript/unittest/jstestdriver/sensortests/test/awesome/AnotherPersonTest.js
@@ -1,0 +1,1 @@
+This is content for awesome AnotherPersonTest.js JavaScript file used in unit tests.


### PR DESCRIPTION
- fix searching for test file corresponding to filename when filename contains a common suffix matching several files
- add unit tests

Reported issue on SonarQube Google group: https://groups.google.com/forum/#!topic/sonarqube/GS4Uq8nipL0