### PR TITLE
org.sonar.api.resources.ProjectFileSystem was deprecated.

### DIFF
--- a/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/cpd/JavaScriptCpdMapping.java
+++ b/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/cpd/JavaScriptCpdMapping.java
@@ -21,8 +21,8 @@ package org.sonar.plugins.javascript.cpd;
 
 import net.sourceforge.pmd.cpd.Tokenizer;
 import org.sonar.api.batch.AbstractCpdMapping;
+import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.resources.Language;
-import org.sonar.api.resources.ProjectFileSystem;
 import org.sonar.plugins.javascript.core.JavaScript;
 
 import java.nio.charset.Charset;
@@ -32,9 +32,9 @@ public class JavaScriptCpdMapping extends AbstractCpdMapping {
   private final JavaScript language;
   private final Charset charset;
 
-  public JavaScriptCpdMapping(JavaScript language, ProjectFileSystem fs) {
+  public JavaScriptCpdMapping(JavaScript language, FileSystem fs) {
     this.language = language;
-    this.charset = fs.getSourceCharset();
+    this.charset = fs.encoding();
   }
 
   @Override

--- a/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/cpd/JavaScriptCpdMappingTest.java
+++ b/sonar-javascript-plugin/src/test/java/org/sonar/plugins/javascript/cpd/JavaScriptCpdMappingTest.java
@@ -20,7 +20,7 @@
 package org.sonar.plugins.javascript.cpd;
 
 import org.junit.Test;
-import org.sonar.api.resources.ProjectFileSystem;
+import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.plugins.javascript.core.JavaScript;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -31,7 +31,7 @@ public class JavaScriptCpdMappingTest {
   @Test
   public void test() {
     JavaScript language = mock(JavaScript.class);
-    ProjectFileSystem fs = mock(ProjectFileSystem.class);
+    FileSystem fs = mock(FileSystem.class);
     JavaScriptCpdMapping mapping = new JavaScriptCpdMapping(language, fs);
     assertThat(mapping.getLanguage()).isSameAs(language);
     assertThat(mapping.getTokenizer()).isInstanceOf(JavaScriptTokenizer.class);


### PR DESCRIPTION
Just a small fix.
We should replace the deprecated classes, is it right?